### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,24 +8,10 @@ assignees: ''
 ---
 
 ## Describe the bug
-A clear and concise description of what the bug is.
-
-### Screenshots
-If applicable, add screenshots to help explain your problem.
-
-## To Reproduce
-Steps to reproduce the behavior:
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
+[A clear and concise description of what the bug is. Please include as much information as possible, such as steps to reproduce, screenshots and/or affected versions.]
 
 ## Expected behavior
-A clear and concise description of what you expected to happen.
-
-## Details:
- - Operating System: [e.g. iOS 17.0]
- - Affected version(s) : [e.g. v1.0.0]
+[A clear and concise description of what you expected to happen.]
 
 ## Additional context
-Add any other context about the problem here.
+[Add any other context about the problem here.]

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,14 +7,7 @@ assignees: ''
 
 ---
 
-## Is your feature request related to a problem? Please describe.
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
-
-## Describe the solution you'd like
-A clear and concise description of what you want to happen.
-
-## Describe alternatives you've considered
-A clear and concise description of any alternative solutions or features you've considered.
+[A clear and concise description of what you want to happen. If this feature request is related to an existing problem, please describe that too.]
 
 ## Additional context
-Add any other context or screenshots about the feature request here.
+[Add any other context or screenshots about the feature request here.]

--- a/.github/ISSUE_TEMPLATE/generic-issue.md
+++ b/.github/ISSUE_TEMPLATE/generic-issue.md
@@ -7,9 +7,7 @@ assignees: ''
 
 ---
 
-## Describe the issue
-Please provide information about this issue you are opening.
-
+[Please provide information about this issue you are opening.]
 
 ## Additional context
-Add any other context or screenshots about this issue here.
+[Add any other context or screenshots about this issue here.]


### PR DESCRIPTION
The existing issue templates were too onerous and took too much time to fill in. This should speed up the workflow for the maintainers, as well as be more inviting to the wider open-source community.