### PR TITLE
Don't truncate subtexts in prominent story promo rows

### DIFF
--- a/ReadBeeb/Components/Reusable/ProminentStoryPromoRow.swift
+++ b/ReadBeeb/Components/Reusable/ProminentStoryPromoRow.swift
@@ -52,8 +52,6 @@ struct ProminentStoryPromoRow: View {
                 if let subtext = self.story.subtext {
                     Text(subtext)
                         .font(.callout)
-                        .lineLimit(2)
-                        .minimumScaleFactor(0.9)
                         .truncationMode(.tail)
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .multilineTextAlignment(.leading)


### PR DESCRIPTION
# Related issues

#48 

# Summary of changes

- Remove truncation of subtexts in prominent story rows

# Summary of testing

Tested in iOS simulator on iPhone 16 Pro (iOS 18.0)

# Steps required for deployment

n/a
