### PR TITLE
Fix live articles not rendering

### DIFF
--- a/ReadBeeb/Screens/DestinationDetailScreen.swift
+++ b/ReadBeeb/Screens/DestinationDetailScreen.swift
@@ -25,7 +25,12 @@ struct DestinationDetailScreen: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            if self.viewModel.isApiUrl {
+            if self.viewModel.destination.presentation.type == .web {
+                StoryWebView(url: self.viewModel.destination.url) {
+                    // Assign any non-empty value to prevent the empty data overlay being displayed
+                    self.viewModel.mockSuccessfulApiRequest()
+                }
+            } else {
                 if let data = self.viewModel.data {
                     switch self.viewModel.destinationType ?? "" {
                     case "index", "topic":
@@ -37,11 +42,6 @@ struct DestinationDetailScreen: View {
                     default:
                         StoryView(data: data)
                     }
-                }
-            } else {
-                StoryWebView(url: self.viewModel.destination.url) {
-                    // Assign any non-empty value to prevent the empty data overlay being displayed
-                    self.viewModel.mockSuccessfulApiRequest()
                 }
             }
         }


### PR DESCRIPTION
# Related issues

Fixes #55 

# Summary of changes

Fixes live articles not rendering in web views. Previsiously they were always rewritten to the API, but the API no longer returns a `newDestination` property that points back to the original destination. Now it only returns a 404.

# Summary of testing

Tested in the iOS Simulator on iOS 18.2. Live articles, web articles and native articles all rendered correctly as expected.

# Steps required for deployment

n/a
