### PR TITLE
Fix topic pages rendering as stories

### DIFF
--- a/ReadBeeb/ViewModels/DestinationDetailViewModel.swift
+++ b/ReadBeeb/ViewModels/DestinationDetailViewModel.swift
@@ -77,7 +77,14 @@ extension DestinationDetailScreen {
 
         /// The type of the destination to be displayed in the view.
         var destinationType: String? {
-            return self.destination.url.valueOf("type")
+            switch self.destination.url.lastPathComponent {
+            case "app-topic-api":
+                return "topic"
+            case "app-article-api":
+                return "asset"
+            default:
+                return self.destination.url.valueOf("type")
+            }
         }
 
         /// If the destination URL is served by the BBC News API.


### PR DESCRIPTION
# Related issues

Fixes #57

# Summary of changes

Parse destination type from API URL to determine what destination page to render.

# Summary of testing

Tested using `https://news-app.api.bbc.co.uk/fd/app-topic-api?page=https%3A%2F%2Fwww.bbc.co.uk%2Fnews%2Ftopics%2Fcdvm824118gt&clientName=Chrysalis&clientVersion=pre-7`
