### PR TITLE
Prevent duplicate copyright disclaimers being shown

### DIFF
--- a/ReadBeeb/Components/Discovery/DiscoveryItemView.swift
+++ b/ReadBeeb/Components/Discovery/DiscoveryItemView.swift
@@ -59,9 +59,10 @@ struct DiscoveryItemView: View {
             Carousel(item: item)
         case .chipList(let item):
             ChipList(item: item)
-        case .copyright(let item):
-            Copyright(item: item)
-                .listRowSeparator(.hidden)
+        case .copyright:
+            // Some API endpoints miss the copyright disclaimer. Instead we hardcode a disclaimer at the bottom of each page, so this can
+            // be ignored here instead.
+            EmptyView()
         #if DEBUG
         case .unknown:
             Text("UNKNOWN value of FDItem decoded")


### PR DESCRIPTION
# Related issues

Closes #60 

# Summary of changes

We already hard code a copyright disclaimer on all pages, as this is intermitently provided by the API itself. As a result, we don't need to obey the API when it attempts to render one. The primary case when this occurs is the topic discovery page.