### PR TITLE
Push tags in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
 XCODE_PROJECT = ReadBeeb.xcodeproj/project.pbxproj
 TOPICS_FILE = ReadBeeb/Files/Topics.json
-BUMP_TYPE=patch
+BUMP=patch
 PUSH=true
 
 release-version:
 	bin/version-bump --xcode-project $(XCODE_PROJECT) --version $(VERSION)
 
 release:
-	bin/version-bump --xcode-project $(XCODE_PROJECT) --bump-type $(BUMP_TYPE)
+	bin/version-bump --xcode-project $(XCODE_PROJECT) --bump-type $(BUMP)
 	ifeq ($(PUSH), true)
 		git push --follow-tags
 	endif

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,12 @@
 XCODE_PROJECT = ReadBeeb.xcodeproj/project.pbxproj
 TOPICS_FILE = ReadBeeb/Files/Topics.json
+BUMP_TYPE=patch
 
 release-version:
 	bin/version-bump --xcode-project $(XCODE_PROJECT) --version $(VERSION)
 
-release-major:
-	bin/version-bump --xcode-project $(XCODE_PROJECT) --bump-type major
-
-release-minor:
-	bin/version-bump --xcode-project $(XCODE_PROJECT) --bump-type minor
-
-release-patch:
-	bin/version-bump --xcode-project $(XCODE_PROJECT) --bump-type patch
-
-release: release-patch
+release:
+	bin/version-bump --xcode-project $(XCODE_PROJECT) --bump-type $(BUMP_TYPE)
 
 topics:
 	bin/fetch-topics $(API_KEY) > $(TOPICS_FILE)

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,16 @@
 XCODE_PROJECT = ReadBeeb.xcodeproj/project.pbxproj
 TOPICS_FILE = ReadBeeb/Files/Topics.json
 BUMP_TYPE=patch
+PUSH=true
 
 release-version:
 	bin/version-bump --xcode-project $(XCODE_PROJECT) --version $(VERSION)
 
 release:
 	bin/version-bump --xcode-project $(XCODE_PROJECT) --bump-type $(BUMP_TYPE)
+	ifeq ($(PUSH), true)
+		git push --follow-tags
+	endif
 
 topics:
 	bin/fetch-topics $(API_KEY) > $(TOPICS_FILE)

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ PUSH=true
 
 release-version:
 	bin/version-bump --xcode-project $(XCODE_PROJECT) --version $(VERSION)
+	ifeq ($(PUSH), true)
+		git push --follow-tags
+	endif
 
 release:
 	bin/version-bump --xcode-project $(XCODE_PROJECT) --bump-type $(BUMP)

--- a/README.md
+++ b/README.md
@@ -62,14 +62,9 @@ make topics API_KEY=<BBC News OAuth2 Token>
 ## Release
 
 On the `main` branch:
-1. Bump the version and build number, and tag the project
+1. Bump the version and build number, tag the project and push:
 ```
-make release # Defaults to patch
-make release-<major|minor|patch>
-make release-version VERSION=<version>
+make release VERSION=<version> PUSH=<true|false>
+make release BUMP=<major|minor|patch> PUSH=<true|false>
 ```
-2. Push to the remote
-```
-git push --follow-tags
-```
-3. Create a corresponding [release](https://github.com/bilaalrashid/ReadBeeb/releases/new) on GitHub
+2. Create a corresponding [release](https://github.com/bilaalrashid/ReadBeeb/releases/new) on GitHub


### PR DESCRIPTION
# Related issues

Closes #62

# Summary of changes

Push git tag directly in the Makefile when bumping.

# Summary of testing

```
bilaal@Bilaals-MacBook-Pro ~/Developer/Xcode/ReadBeeb (bilaal/makefile-release) $ make release -n 
bin/version-bump --xcode-project ReadBeeb.xcodeproj/project.pbxproj --bump-type patch
ifeq (true, true)
git push --follow-tags
endif
bilaal@Bilaals-MacBook-Pro ~/Developer/Xcode/ReadBeeb (bilaal/makefile-release) $ make release BUMP=patch -n
bin/version-bump --xcode-project ReadBeeb.xcodeproj/project.pbxproj --bump-type patch
ifeq (true, true)
git push --follow-tags
endif
bilaal@Bilaals-MacBook-Pro ~/Developer/Xcode/ReadBeeb (bilaal/makefile-release) $ make release BUMP=minor -n
bin/version-bump --xcode-project ReadBeeb.xcodeproj/project.pbxproj --bump-type minor
ifeq (true, true)
git push --follow-tags
endif
bilaal@Bilaals-MacBook-Pro ~/Developer/Xcode/ReadBeeb (bilaal/makefile-release) $ make release BUMP=major -n
bin/version-bump --xcode-project ReadBeeb.xcodeproj/project.pbxproj --bump-type major
ifeq (true, true)
git push --follow-tags
endif
bilaal@Bilaals-MacBook-Pro ~/Developer/Xcode/ReadBeeb (bilaal/makefile-release) $ make release VERSION=1.0.0 -n
bin/version-bump --xcode-project ReadBeeb.xcodeproj/project.pbxproj --bump-type patch
ifeq (true, true)
git push --follow-tags
endif
bilaal@Bilaals-MacBook-Pro ~/Developer/Xcode/ReadBeeb (bilaal/makefile-release) $ make release PUSH=true -n
bin/version-bump --xcode-project ReadBeeb.xcodeproj/project.pbxproj --bump-type patch
ifeq (true, true)
git push --follow-tags
endif
bilaal@Bilaals-MacBook-Pro ~/Developer/Xcode/ReadBeeb (bilaal/makefile-release) $ make release PUSH=false -n 
bin/version-bump --xcode-project ReadBeeb.xcodeproj/project.pbxproj --bump-type patch
ifeq (false, true)
git push --follow-tags
endif
```
